### PR TITLE
Fix link for Hamlof Red-Tooth

### DIFF
--- a/speedrun-3.html
+++ b/speedrun-3.html
@@ -99,7 +99,7 @@ Restoration</li>
 <li><a href="glitches.html#duping">Dupe</a> the 1 stack using the 2 stack, pick one up, then repeat and pick up all scrolls so that you have 3 of one scroll and 2 of another. Now, dupe the stacks back and forth until you have 512 of one and 768 of another.</li>
 <li>From the 768 stack, sell 200, 200, then 68 scrolls back to Calindil. From the 512 stack, sell 200, 200, then 62 scrolls. You should have 300 of one type, and 50 of another, as well as over 4,300 gold at the end. </li>
 <li>Read <span class="replaceable" clid="book87">The Black Arts on Trial [Mysticism]</span> skill book on the counter.</li>
-<li>Head SE to Red Diamond Jewelry. Talk to <span class="npc">Hamlof</span> and buy the Brass Ring. Dupe about 300 lockpicks.</li>
+<li>Head SE to Red Diamond Jewelry. Talk to <span class="npc">Hamlof Red-Tooth</span> and buy the Brass Ring. Dupe about 300 lockpicks.</li>
 </ol>
 </div>
 


### PR DESCRIPTION
The link for Hamlof is broke due to not including his full name. Now links correctly to the UESP wiki page