### PR TITLE
Make Autoreader Find Nested Text

### DIFF
--- a/autoread.js
+++ b/autoread.js
@@ -26,8 +26,7 @@ function goToNext(){
 		//update section
 		var sections = document.getElementsByClassName("section");
 		var thisSection = sections[currentSection];
-		var thislist = Array.from(thisSection.children).find(x=>x.tagName=="OL")
-		sectionLines = thislist.children;
+		sectionLines = thisSection.querySelectorAll("li")
 		sectionLines[currentLineIndex].style.backgroundColor="lightyellow";
 		currentLineText = sectionLines[currentLineIndex].innerText;
 	}

--- a/autoread.js
+++ b/autoread.js
@@ -16,8 +16,9 @@ function goToNext(){
 	
 	currentLineIndex +=1;
 	if(currentLineIndex < sectionLines?.length){
-		sectionLines[currentLineIndex].style.backgroundColor="lightyellow";
-		currentLineText = sectionLines[currentLineIndex].innerText;
+		let currentLine = sectionLines[currentLineIndex];
+		currentLine.style.backgroundColor="lightyellow";
+		currentLineText = currentLine.innerText;
 	}
 	else
 	{
@@ -27,8 +28,10 @@ function goToNext(){
 		var sections = document.getElementsByClassName("section");
 		var thisSection = sections[currentSection];
 		sectionLines = thisSection.querySelectorAll("li")
-		sectionLines[currentLineIndex].style.backgroundColor="lightyellow";
-		currentLineText = sectionLines[currentLineIndex].innerText;
+
+		let currentLine = sectionLines[currentLineIndex];
+		currentLine.style.backgroundColor="lightyellow";
+		currentLineText = currentLine.innerText;
 	}
 }
 


### PR DESCRIPTION
Previously the autoreader was dependent on the structure of the html to find the text lines to read. It will now search for any \<li> tags in each section and read the text from those out. This closes #19 .

This also allows pull request #32 to be merged without breaking the reader.

It also partially solves issue #18 : The reader will now read each individual line of a sublist. However, it will first read the entire sublist as part of the \<li> containing it. I'm sure some sort of fancy checking and removing of that content when it loads the section in would work, but after looking at it for a bit I shelved it since I'm not sure its worth figuring out.