### PR TITLE
Fix small speedrun guide formatting issues.

### DIFF
--- a/speedrun-3.html
+++ b/speedrun-3.html
@@ -236,7 +236,7 @@ under the first building.</li>
 <li>Fast travel to the Mages Guild Quest Marker to talk to Teekeeus.
 <ol><li>Dialogue: Fingers of the Mountain.</li>
 <li>Dialogue: Here’s the book. (this completes <span class="replaceable" clid="quest91">the quest</span>)</li></ol></li>
-<li>Go outside and find <span class="npc">Earana</span> again. She may be at the Grey Mare near the south end of town.</li>
+<li>Go outside and find <span class="npc">Earana</span> again. She may be at the Grey Mare near the south end of town.
 <ol><li>Advance predetermined dialogue.
 <li>Dialogue: No, I won’t do that. (This completes <span class="replaceable" clid="quest92">Fingers of the Mountain, Part II</span>.)</li></ol></li>
 </div>

--- a/speedrun-3.html
+++ b/speedrun-3.html
@@ -201,7 +201,7 @@ Use the following method to increase your movement speed everywhere you go:<br/>
 <li>Exit the well and go around to the front of the south building to enter the Mages Guild.</li>
 <li>Head east down into the basement.</li>
 <li>Read <span class="replaceable" clid="book88">The Firsthold Revolt [Mysticism]</span> on the bookshelf next to the crystal ball at the bottom of the stairs.</li>
-<li>Head west and open the locked door, then open the locked drawers and take the Black Soul Gems.</li>
+<li>Head west and open the locked door, then open the locked drawers and take the Black Soul Gems.
 <ol><li>If this door does not open, load <span class="replaceable" clid="savepermakey" disabled="true">the PermaKey_Save</span> and do the Perma Key glitch.</li></ol></li>
 <li>Talk to <span class="npc">Falcar</span>. He may be anywhere in the building and is wearing black.
 <ol><li>Dialogue: Recommendation.


### PR DESCRIPTION
The general format for guide content with sublists is

\<section\>
\<section title />
\<ol>
\<li>normal entry\</li>
\<li>entry with sublist
  \<ol>
    \<li>sublist item 1\</li>
    \<li>sublist item 2\</li>
  \</ol>
\</li>
\</ol>
\</section\>

This fixes two cases where an extra closing tag was making the format inconsistent.