### PR TITLE
Topbar and speechbox fixes.

### DIFF
--- a/autoread.js
+++ b/autoread.js
@@ -59,10 +59,11 @@ function initSpeak(){
 	// Disable the "Enable Speech" button
 	let enableSpeechBtn = document.getElementById("enable_speech_btn");
 	enableSpeechBtn.disabled = true;
+	enableSpeechBtn.blur(); //take focus off of button, so we can press space right away
 }
 
 function addSpeakBox(){
-	
+	/*
 	var speechBox = document.createElement("div");
 	speechBox.id = "speechbox"
 	speechBox.style.float="right";
@@ -97,12 +98,19 @@ function addSpeakBox(){
 		document.body.prepend(outerSpeechBox);
 	}
 	outerSpeechBox.appendChild(speechBox);
+	*/
+
+	var TBar = document.getElementById("topbar");
+	var speechBox = document.createElement("div");
+
+	speechBox.className = "topbarSection";
+	speechBox.style.backgroundColor = "lightgreen";
+	speechBox.innerText = "Speech Enabled.";
+	TBar.append(speechBox);
 
 	window.addEventListener('resize', orientationCheck, true);
 	window.addEventListener('keydown', playHotKey, true);
 	window.addEventListener('touchstart', playHotKey, true);
-
-	sbPlay.focus();
 }
 
 function handleCheckbox(currentLine){

--- a/autoread.js
+++ b/autoread.js
@@ -9,7 +9,6 @@ var currentLineText = "";
 function goToNext(){
 	if(sectionLines && sectionLines[currentLineIndex]){
 		sectionLines[currentLineIndex].style.backgroundColor="";
-		sectionLines[currentLineIndex].scrollIntoView({behavior: "smooth", block: "center", inline: "nearest"});
 	}
 	
 	currentLineIndex +=1;
@@ -47,6 +46,9 @@ function playHotKey(event){
 		event.preventDefault();
 		goToNext();
 		play();
+	}
+	if(event.key == " " && sectionLines && sectionLines[currentLineIndex]){
+		sectionLines[currentLineIndex].scrollIntoView({behavior: "smooth", block: "center", inline: "nearest"});
 	}
 }
 

--- a/autoread.js
+++ b/autoread.js
@@ -108,7 +108,6 @@ function addSpeakBox(){
 	speechBox.innerText = "Speech Enabled.";
 	TBar.append(speechBox);
 
-	window.addEventListener('resize', orientationCheck, true);
 	window.addEventListener('keydown', playHotKey, true);
 	window.addEventListener('touchstart', playHotKey, true);
 }
@@ -125,21 +124,4 @@ function handleCheckbox(currentLine){
 
 function handleSublist(currentLine){
 	return Array.of(...currentLine.childNodes).filter(x=>x.nodeName != "OL" && x.nodeName != "UL").map(x=>x.textContent).join('');
-}
-
-function orientationCheck(){
-		let sBar = document.getElementById("sidebar");
-		let sBox = document.getElementById("speechbox");
-		
-		if(window.innerHeight + 100 > window.innerWidth){
-			//portrait mode
-			sBar.style.position="fixed";
-			sBar.style.bottom="1em";
-			sBox.style.border="2px solid black";
-		}
-		else{
-			//landscape mode
-			sBar.style.position="static";
-			sBox.style.border="1px solid black";
-		}
 }

--- a/autoread.js
+++ b/autoread.js
@@ -121,7 +121,7 @@ function orientationCheck(){
 		let sBar = document.getElementById("sidebar");
 		let sBox = document.getElementById("speechbox");
 		
-		if(window.innerHeight > window.innerWidth){
+		if(window.innerHeight + 100 > window.innerWidth){
 			//portrait mode
 			sBar.style.position="fixed";
 			sBar.style.bottom="1em";

--- a/autoread.js
+++ b/autoread.js
@@ -62,6 +62,7 @@ function initSpeak(){
 function addSpeakBox(){
 	
 	var speechBox = document.createElement("div");
+	speechBox.id = "speechbox"
 	speechBox.style.float="right";
 	speechBox.style.backgroundColor="#FBEFD5";
 	speechBox.style.border="1px solid black";
@@ -94,7 +95,8 @@ function addSpeakBox(){
 		document.body.prepend(outerSpeechBox);
 	}
 	outerSpeechBox.appendChild(speechBox);
-	
+
+	window.addEventListener('resize', orientationCheck, true);
 	window.addEventListener('keydown', playHotKey, true);
 	window.addEventListener('touchstart', playHotKey, true);
 
@@ -113,4 +115,21 @@ function handleCheckbox(currentLine){
 
 function handleSublist(currentLine){
 	return Array.of(...currentLine.childNodes).filter(x=>x.nodeName != "OL" && x.nodeName != "UL").map(x=>x.textContent).join('');
+}
+
+function orientationCheck(){
+		let sBar = document.getElementById("sidebar");
+		let sBox = document.getElementById("speechbox");
+		
+		if(window.innerHeight > window.innerWidth){
+			//portrait mode
+			sBar.style.position="fixed";
+			sBar.style.bottom="1em";
+			sBox.style.border="2px solid black";
+		}
+		else{
+			//landscape mode
+			sBar.style.position="static";
+			sBox.style.border="1px solid black";
+		}
 }

--- a/autoread.js
+++ b/autoread.js
@@ -100,13 +100,13 @@ function addSpeakBox(){
 	outerSpeechBox.appendChild(speechBox);
 	*/
 
-	var TBar = document.getElementById("topbar");
+	var tBar = document.getElementById("topbar");
 	var speechBox = document.createElement("div");
 
 	speechBox.className = "topbarSection";
 	speechBox.style.backgroundColor = "lightgreen";
 	speechBox.innerText = "Speech Enabled.";
-	TBar.append(speechBox);
+	tBar.append(speechBox);
 
 	window.addEventListener('keydown', playHotKey, true);
 	window.addEventListener('touchstart', playHotKey, true);

--- a/glitches.html
+++ b/glitches.html
@@ -53,18 +53,8 @@
 	</div>
 	
 	<a href="./settings.html" class="topbarSection"> Settings</a>
-	
 </div>
-
-<div id="topbar" class="topbar">
-	<div id="links">
-		<a href="./index.html">Checklist</a> | 
-		<a href="./glitches.html">Glitches</a> | 
-		<a href="./casual.html">Casual Guide</a> | 
-		<a href="./speedrun-3.html">Speedrun Guide (v3)</a> | 
-		<a href="./settings.html">Settings</a>
-	</div>
-</div>
+<br/>
 <h1>Oblivion Glitch Reference Guide</h1>
 <h3>Made by Ben Songster (MeemawHustlin)</h3>
 <p>This document is designed to give you a quick reference of how to perform several glitches that may be useful throughout the 100% completion challenge. None of these are required to get 100% completion. Bolded ones are highly recommended to save you a lot of time for minimal effort.</p>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 			<a href="./speedrun-3.html#guide_MainQuestPt2">Main Quest Pt2</a>
 			<a href="./speedrun-3.html#guide_FightersGuild">Fighters Guild</a>
 		</div>
-	<div id="progress" class="progress">Total Progress: <span id="totalProgressPercent">0</span>%</div>
+	</div>
 	
 	<a href="./settings.html" class="topbarSection"> Settings</a>
 

--- a/main.css
+++ b/main.css
@@ -46,7 +46,7 @@ td{
 	justify-content: space-evenly;
 	align-items:stretch;
 	width: 99%; /*99% prevents the rightside of the topbar from hiding behind the scrollbar*/
-	max-height: 1em;
+	max-height: 2em;
 	position: fixed;
 	background-color: #FBEFD5;
 	padding:0.5em;
@@ -55,7 +55,7 @@ td{
 }
 
 .topbarSection{
-	flex:1 0 20%;
+	flex:1 0 16%;
 	text-align: center;
 	background-color: #EBDFC5;
 	border-right: 1px solid black;


### PR DESCRIPTION
Topbar in index was missing a closing div tag

auto-scroll for mobile is disabled. a tap still progresses speechbox

speechbox indicator will spawn on topbar now, sidebar only handles iframe atm.
    - the formatting for speechbox to go on the sidebar is still in autoread.js, it's just commented out in case we ant to use it again.

mobile formatting is handled via main.css now, and not autoread.js anymore.

will resolve #62 