### PR TITLE
Map fixes

### DIFF
--- a/guide.css
+++ b/guide.css
@@ -124,5 +124,5 @@ img{
 
 .nirnroot{
 	font-weight: bold;
-	color:seagreen;
+	color:blue;
 }

--- a/js/map.mjs
+++ b/js/map.mjs
@@ -24,14 +24,13 @@ export {
     getCtx
 };
 
-import {Point} from "./map/point.mjs";
+import { Point } from "./map/point.mjs";
 import { MapPOI } from "./map/mapObject.mjs";
 import { sumCompletionItems } from "./progressCalculation.mjs";
-import { saveCookie } from "./userdata.mjs"
-import { Overlay, OVERLAY_LAYER_LOCATIONS, OVERLAY_LAYER_NIRNROOTS } from "./map/overlay.mjs";
+import { saveCookie, saveProgressToCookie } from "./userdata.mjs"
+import { Overlay, OVERLAY_LAYER_LOCATIONS, OVERLAY_LAYER_NIRNROOTS, OVERLAY_LAYER_WAYSHRINES } from "./map/overlay.mjs";
 import { findCell } from "./obliviondata.mjs";
 import { resetProgressForHive } from "./userdata.mjs";
-import { OVERLAY_LAYER_WAYSHRINES } from "./map/overlay.mjs";
 
 /**
  * The element that contains the canvas. We can use this to query for how much of the canvas the user can see.
@@ -108,6 +107,12 @@ function updateRandomGateCount(Found){
         randomGateDisplay.innerText = getRandomGateCount();    
         randomGateDisplay.style = "color:black";
     }
+}
+
+function clearRandomGateCount(){
+    randomGateCount = 0;
+    randomGateDisplay.innerText = getRandomGateCount();    
+    randomGateDisplay.style = "color:black";
 }
 
 function initRandomGateCount(){
@@ -482,6 +487,9 @@ function initListeners(){
         if(confirm("Delete saved map progress?")){
             resetProgressForHive(jsondata.location);
             resetProgressForHive(jsondata.nirnroot);
+            clearRandomGateCount();
+            saveProgressToCookie();
+            location.reload();
         }
     });
 }


### PR DESCRIPTION
changed nirnroot text color to blue hexcode from guide.
closes https://github.com/MichaelEbert/OblivionProgressTracker/issues/233


I couldn't find out why, but it seems that the page keeps the old data for calculate progress and doesn't update it until reload.
My solution is to reload the page after resetting location data.
There's probably a way to do it without a reload, but I do not know at this point in time.
if this is good enough,
closes https://github.com/MichaelEbert/OblivionProgressTracker/issues/222