### PR TITLE
Added auto fullscreen on mobile

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -444,3 +444,7 @@ h1{
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+:fullscreen, ::backdrop {
+    background-color: var(--base-color);
+}

--- a/guide.js
+++ b/guide.js
@@ -1,5 +1,7 @@
 "use strict"
 
+
+
 var linkedElements = [];
 
 function LinkedElement(element, classname, id){
@@ -18,6 +20,28 @@ function init(){
 		sharing.initSharingFeature();
 		replaceElements();
 	});
+
+	document.addEventListener("touchend", (e) => {
+		if (!document.documentElement.fullscreenElement) {
+			setMobileFullscreen();
+		}
+	  }, false);
+}
+
+function setMobileFullscreen(){
+	console.log(document.documentElement.requestFullscreen);
+	if(document.documentElement.requestFullscreen) {
+    	document.documentElement.requestFullscreen();     // Standard
+  	}
+  	else if (document.documentElement.mozRequestFullScreen) {
+    	document.documentElement.mozRequestFullScreen();     // Firefox
+  	}
+  	else if (document.documentElement.webkitRequestFullscreen) {
+    	document.documentElement.webkitRequestFullscreen();  // Safari
+  	}
+  	else if(document.documentElement.msRequestFullscreen) {
+    	document.documentElement.msRequestFullscreen();      // IE/Edge
+  	}
 }
 
 /**


### PR DESCRIPTION
A quick attempt to make mobile go fullscreen. After first user interaction with the webpage on mobile, it will go fullscreen. Tested on firefox and chrome on mobile.

Please heavily scrutinize as I have not worked with this particular thing before and may be missing something. I know on chrome the console has a seemingly benign warning that shows up but the feature still works so if anyone knows how to catch that error so it doesn't appear anymore lmk.