### PR TITLE
V3 Guide Nirnroot Bug Fix

### DIFF
--- a/speedrun-3.html
+++ b/speedrun-3.html
@@ -216,7 +216,7 @@ Restoration</li>
 <li>Fast travel to Cheydinhal West Gate.</li>
 <li>Head SE around the back of the first building to enter the well.
 <ol><li>If this door does not open, load <span class="save" clid="savepermakey" disabled="true">the PermaKey_Save</span> and do the Perma Key glitch.</li></ol></li>
-<li>Get the <span class="nirnroot">Nirnroot</span> at the south end of the well.</li>
+<li>Get the <span class="nirnroot" clid="0x0006F0EA">Nirnroot</span> at the south end of the well.</li>
 <li>On the west end of the well, take the Ring of Burden off of Vidkun’s corpse.</li>
 <li>Exit the well and go around to the front of the south building to enter the Mages Guild.</li>
 <li>Head east down into the basement.</li>
@@ -405,7 +405,7 @@ After completing all of the Mages Guild Recommendations, you should now have all
 <ol>
 <li>Read <span class="book" clid="book86">Before the Ages of Man [Mysticism]</span> on the altar to your immediate right. </li>
 <li>Go outside and head left into the Lustratorium and read <span class="book" clid="book10">Song of the Alchemists [Alchemy]</span> on the bookshelf on the back wall. </li>
-<li>Next, exit and start heading to the right towards the farthest door. On the way, go into the Mage’s Quarters and grab the <span class="nirnroot">Nirnroot</span> in the side room on the main floor. Leave and continue moving towards the far end of the Arcane University.</li>
+<li>Next, exit and start heading to the right towards the farthest door. On the way, go into the Mage’s Quarters and grab the <span class="nirnroot" clid="0x0006F26B">Nirnroot</span> in the side room on the main floor. Leave and continue moving towards the far end of the Arcane University.</li>
 </ol>
 Once you get to the Praxographical Center, go to the spellmaking altar and create the following spell: <b>The naming conventions of spells will be used throughout the guide.</b>
 <br/>
@@ -512,16 +512,16 @@ Do the following additional tasks at various peoples’ stores/homes:
 <li>Mach-Na’s Books:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x00003641">Mach-Na</span>.
 		<ul><li>Buy and read <span class="book" clid="book96">Advances in Lock Picking [Security]</span>.</li></ul></li>
-	<li><span class="nirnroot">Nirnroot</span> in the upstairs bedroom.</li></ul></li>
+	<li><span class="nirnroot" clid="0x0006F0DF">Nirnroot</span> in the upstairs bedroom.</li></ul></li>
 <li>The March Rider:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000363B">Tertia Viducia</span>.</li></ul></li>
 <li>Mages Guild:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000364A">Eilonwy</span>.</li></ul></li>
 <li>Willow Bank:
 	<ul><li>Read <span class="book" clid="book65">Incident in Necrom [Illusion]</span> on the second floor table by the bed.</li></ul></li>
-<li><span class="nirnroot">Nirnroot</span> next to the bridge.</li>
+<li><span class="nirnroot" clid="0x0006F0E4">Nirnroot</span> next to the bridge.</li>
 <li>Riverview:
-	<ul><li><span class="nirnroot">Nirnroot</span> at top of stairs.</li></ul></li>
+	<ul><li><span class="nirnroot" clid="0x0006F0F0">Nirnroot</span> at top of stairs.</li></ul></li>
 <li>Ganredhel’s House:
 	<ul><li>Talk to <span class="npc">Ganredhel</span> to start the <span class="quest" clid="quest147" disabled="true">Acrobatics Training</span> quest using <span class="spellname">B_Acrobatics</span>. Wait until 1pm-2pm before entering the house.</li>
 	<li>Read <span class="book" clid="book2">A Dance in Fire, v1 [Acrobatics]</span> on the dresser upstairs.</li></ul></li>
@@ -575,7 +575,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<ul><li>Read <span class="book" clid="book94">Notes on Racial Phylogeny [Restoration]</span> in the Chapel Hall, west side room in a chest.</li>
 	</ul></li>
 <li>Casta Scribonia’s House:
-	<ul><li><span class="nirnroot">Nirnroot </span>upstairs.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F25C">Nirnroot </span>upstairs.</li>
 	<li>Read <span class="book" clid="book82">A Dance in Fire, v6 [Mercantile]</span>, upstairs on a shelf.</li>
 	</ul></li>
 </ol>
@@ -589,9 +589,9 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<ul><li>Read <span class="book" clid="book41">2920, Frostfall (v10) [Conjuration]</span> in the Chapel Hall on a desk in the east side room.</li>
 	</ul></li>
 <li>Heinrich Oaken-Hull’s House:
-	<ul><li><span class="nirnroot">Nirnroot</span> upstairs in a side room.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F0CB">Nirnroot</span> upstairs in a side room.</li>
 	</ul></li>
-<li><span class="nirnroot">Nirnroot </span>by the statue.</li>
+<li><span class="nirnroot" clid="0x0006F225">Nirnroot </span>by the statue.</li>
 <li>Fighters Guild:
 	<ul><li>Talk to <span class="npc">Azzan</span> to start the <span class="quest" clid="quest154" disabled="true">Blunt Training</span> quest using <span class="spellname">B_Blunt</span>.
 	<ol>
@@ -741,7 +741,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<li>Bribe <span class="npc">Ontus Vanin</span> to full disposition between 12pm and 2pm on any day but Sundas or Loredas.</li>
 	</ul></li>
 <li>Samuel Bantien’s House:
-	<ul><li><span class="nirnroot">Nirnroot </span>upstairs.</li>
+	<ul><li><span class="nirnroot" clid="0x0006D968">Nirnroot </span>upstairs.</li>
 	</ul>
 </ol>
 </div>
@@ -765,7 +765,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<li>Dialogue: Training. (This completes the <span class="quest" clid="quest167">Speechcraft Training</span> quest.)</li>
 	</ol></li>
 <li>Salomon Geonette’s House:
-	<ul><li><span class="nirnroot">Nirnroot</span> upstairs.</li>
+	<ul><li><span class="nirnroot" clid="0x0006D96D">Nirnroot</span> upstairs.</li>
 	</ul></li>
 <li>Marana Rian’s House:
 	<ul><li>Wait until 6am-noon to kill <span class="npc">Marana Rian</span> to complete the <span class="quest" clid="quest166">Sneak Training</span> quest. Pay the gold fine to a guard if you get caught.</li>
@@ -790,12 +790,12 @@ Do the following additional tasks at various peoples’ stores/homes:
 <a href="images/InvestingCircuit_Bravil.png" target="_blank"><img src="images/InvestingCircuit_Bravil.png" name="Image8" width="353" height="408" border="0" align="bottom"></a>
 <ol>
 <li>City-Swimmer’s House (Top Floor):
-	<ul><li><span class="nirnroot">Nirnroot </span>in the house.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F23A">Nirnroot </span>in the house.</li>
 	<li>Read <span class="book" clid="book101">2920, Last Seed (v8) [Sneak] </span>on drawers.</li>
 	</ul></li>
 <li>Silverhome on the Water:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000A129">Gilgondorin</span>.</li>
-	<li><span class="nirnroot">Nirnroot </span>on the third floor, right side room.</li>
+	<li><span class="nirnroot" clid="0x0006F244">Nirnroot </span>on the third floor, right side room.</li>
 	</ul></li>
 <li>The Fair Deal:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000A123">Nilawen</span>.</li>
@@ -803,14 +803,14 @@ Do the following additional tasks at various peoples’ stores/homes:
 	</ul></li>
 <li>Andragil’s House (Top Floor):
 	<ul><li>Start her training and kill <span class="npc">Andragil </span>to complete the <span class="quest" clid="quest153">Block Training</span> quest.</li>
-	<li><span class="nirnroot">Nirnroot </span>by the bed.</li>
+	<li><span class="nirnroot" clid="0x0006F234">Nirnroot </span>by the bed.</li>
 	</ul></li>
 <li>Dro’shanji’s House:
 	<ul><li>Read <span class="book" clid="book100">The Wolf Queen, v 1 [Security]</span> on the shelf upstairs.</li>
 	</ul></li>
 <li>Fighters Guild:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000A118">Tadrose Helas</span>.</li>
-	<li><span class="nirnroot">Nirnroot </span>on the second floor, turn right, first door on your left.</li>
+	<li><span class="nirnroot" clid="0x0006F23F">Nirnroot </span>on the second floor, turn right, first door on your left.</li>
 	</ul></li>
 <li>Mages Guild:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0002F080">Ardaline</span>.</li>
@@ -820,7 +820,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<li>Talk to <span class="npc">Kud-Ei </span>to start the <span class="quest" clid="quest159">Illusion Training</span> quest using <span class="spellname">B_Illusion</span>.</li>
 	<li>Read <span class="book" clid="book48">The Horrors of Castle Xyr [Destruction]</span> on the third floor. (Large brown book on the shelf)</li>
 	</ul></li>
-<li><span class="nirnroot">Nirnroot </span>outside behind the Mages Guild.</li>
+<li><span class="nirnroot" clid="0x0006DC42">Nirnroot </span>outside behind the Mages Guild.</li>
 <li>The Lonely Suitor Lodge:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000A117">Bogrum Gro-Galash</span>.</li>
 	<li><b>Invest</b> in <span class="store" clid="0x0000A130">Luciana Galena</span> if she is here.
@@ -834,13 +834,13 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0000A130">Luciana Galena</span> if you haven’t already.
 	<ul><li>Talk to her to start the <span class="quest" clid="quest160">Light Armor Training</span> quest using <span class="spellname">B_LightArmor</span>.</li></ul></li>
 	</ul></li>
-<li><span class="nirnroot">Nirnroot </span>outside, behind Luciana Galena’s House.</li>
+<li><span class="nirnroot" clid="0x0006DC44">Nirnroot </span>outside, behind Luciana Galena’s House.</li>
 </ol>
 </div>
 
 <div class="category" id="guide_InvestingCircuit_BravilMisc">
 <div class="categoryTitle">Bravil Misc:</div>
-<ul><li>Fast travel to Castle Bravil, and head SW along the wall to find another <span class="nirnroot">Nirnroot</span>.</li>
+<ul><li>Fast travel to Castle Bravil, and head SW along the wall to find another <span class="nirnroot" clid="0x0006DC46">Nirnroot</span>.</li>
 </ul>
 </div>
 
@@ -863,7 +863,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 		<li>Dialogue: Draconian Madstone.</li>
 		<li>Dialogue: Yes.</li>
 		</ol></li>
-	<li><span class="nirnroot">Nirnroot </span>in Lord’s Manor. Enter through the Service Hall, then start sneaking and go through the door on the left, then the next door on the left, where the Nirnroot is. Pay the gold fine to a guard if you get caught.</li>
+	<li><span class="nirnroot" clid="0x0006F253">Nirnroot </span>in Lord’s Manor. Enter through the Service Hall, then start sneaking and go through the door on the left, then the next door on the left, where the Nirnroot is. Pay the gold fine to a guard if you get caught.</li>
 	<li>Read <span class="book" clid="book63">How Orsinium Passed to Orcs [Heavy Armor]</span> on the desk in the Countess’ bedroom on your way out.</li>
 	</ol></li>
 <li>Nord Winds:
@@ -888,7 +888,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 		</ol></li>
 	</ol></li>
 <li>Regner’s House:
-	<ul><li><span class="nirnroot">Nirnroot </span>downstairs.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F258">Nirnroot </span>downstairs.</li>
 	<li>Read <span class="book" clid="book76">A Dance in Fire, v5 [Marksman]</span> on a table downstairs.</li>
 	</ul></li>
 <li>Olav’s Tap and Tack:
@@ -911,7 +911,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 <a href="images/InvestingCircuit_Skingrad.png" target="_blank"><img src="images/InvestingCircuit_Skingrad.png" name="Image10" width="415" height="399" border="0" align="bottom"></a>
 <ol>
 <li>Toutius Sextius’ House:
-	<ul><li><span class="nirnroot">Nirnroot </span>on the third floor.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F29D">Nirnroot </span>on the third floor.</li>
 	</ul></li>
 <li>Hammer and Tongs:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x00028F9A">Agnete the Pickled</span>.</li>
@@ -921,7 +921,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<li>Read <span class="book" clid="book7">De Rerum Dirennis [Alchemy]</span> on a shelf upstairs.</li>
 	</ul></li>
 <li>Surilie Brothers’ House:
-	<ul><li><span class="nirnroot">Nirnroot </span>on the third floor, furthest side door. Boost jump up to the balcony to break in.</li>
+	<ul><li><span class="nirnroot" clid="0x0006F298">Nirnroot </span>on the third floor, furthest side door. Boost jump up to the balcony to break in.</li>
 	</ul></li>
 <li>Two Sisters Lodge:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x00028F8B">Mog gra-Mogakh</span>.</li>
@@ -947,7 +947,7 @@ Do the following additional tasks at various peoples’ stores/homes:
 <li>The Dividing Line:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x00035294">Tun-Zeeus</span>.</li>
 	</ul></li>
-<li><span class="nirnroot">Nirnroot</span> by the rocks.</li>
+<li><span class="nirnroot" clid="0x0006DC38">Nirnroot</span> by the rocks.</li>
 <li>Three Sisters’ Inn:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0003528D">Shuravi</span>.</li>
 	</ul></li>
@@ -955,8 +955,8 @@ Do the following additional tasks at various peoples’ stores/homes:
 	<ul><li><b>Invest</b> in <span class="store" clid="0x0003E214">Bugak gro-Bol</span>.</li>
 	<li>Read <span class="book" clid="book14">Reality &amp; Other Falsehoods [Alteration]</span> on the second floor. (Top shelf of bookshelf next to small table.)</li>
 	</ul>
-<li><span class="nirnroot">Nirnroot</span> by a cluster of rocks.</li>
-<li><span class="nirnroot">Nirnroot</span> by rocks.</li>
+<li><span class="nirnroot" clid="0x0006DC33">Nirnroot</span> by a cluster of rocks.</li>
+<li><span class="nirnroot" clid="0x0006DC36">Nirnroot</span> by rocks.</li>
 </ol>
 </div>
 <p><b>You should now have 56 Stores Invested In.</b></p>
@@ -1527,7 +1527,7 @@ As you explore, do the following tasks at these locations (Ayleid statues are li
 </ol>
 <li><span class="location">Fieldhouse Cave </span> Read <span class="book">Way of the Exposed Palm [Hand to Hand]</span> by hugging the right wall in the first zone, then in the second zonetaking the first two lefts and going through the SSE door in the next clearing. The book is under the big mushroom.</li>
 <li><span class="location">Fort Carmala </span> Stay right until you find a Wooden Chest with 2 Shadowbanish Wine.</li>
-<li><span class="location">Fort Cedrian </span> Hug the left wall to find <span class="nirnroot">Nirnroot</span> in the first zone at the edge of the water.</li>
+<li><span class="location">Fort Cedrian </span> Hug the left wall to find <span class="nirnroot" clid="0x0006F2A0">Nirnroot</span> in the first zone at the edge of the water.</li>
 <li><span class="location">Fort Cuptor </span> Read <span class="book">Souls, Black and White [Mysticism]</span> by hugging the right wall in the first zone, then hugging the left wall and goingthrough a big door to find the book next to a bed at the top of the stairs.</li>
 <ul>
 	<li>Mysticism can now be safely maxed out since all skill books for it have now been read.</li>
@@ -1537,11 +1537,11 @@ As you explore, do the following tasks at these locations (Ayleid statues are li
 	<li>Find 2 Shadowbanish Wine by hugging the left wall until you find a flat-topped wooden chest.</li>
 	<li>Leave the fort and activate the <span class="quest">Destruction Training</span> quest and follow the Quest Marker to find and kill <span class="npc">Bralsa Andaren</span> to complete the quest.</li>
 </ol>
-<li><span class="location">Fort Roebeck</span> Hug the left wall until you go through a gate and a locked door, then follow the path until you see <span class="nirnroot">Nirnroot</span> in the firstzone at the edge of the water.</li>
+<li><span class="location">Fort Roebeck</span> Hug the left wall until you go through a gate and a locked door, then follow the path until you see <span class="nirnroot" clid="0x0006F2A2">Nirnroot</span> in the firstzone at the edge of the water.</li>
 <li><span class="location" clid="0x00015A27">Goblin Jim’s Cave </span> Read <span class="book">Night Falls on Sentinel [Blunt]</span> in the first zone by taking the first left, then heading NW through the tunnelsto find an area with shelves.</li>
-<li><span class="location">Imperial City Sewers - North Exit </span> Go past the gate on your right to activate the turn wheel, then go back through the gate that opens toget the <span class="nirnroot">Nirnroot</span> in the water at the north end of the room.</li>
+<li><span class="location">Imperial City Sewers - North Exit </span> Go past the gate on your right to activate the turn wheel, then go back through the gate that opens toget the <span class="nirnroot" clid="0x0006D91D">Nirnroot</span> in the water at the north end of the room.</li>
 <li><span class="location" clid="0x000177AE">Pell’s Gate </span> Invest in <span class="npc">Candice Corgine</span> at The Sleeping Mare using the <span class="spellname">B_Mercantile</span> spell.</li>
-<p>Get the <span class="nirnroot">Nirnroot</span> in Shafaye’s House.</p>
+<p>Get the <span class="nirnroot" clid="0x0006D946">Nirnroot</span> in Shafaye’s House.</p>
 <li><span class="location">Shardrock </span></li>
 <ol>
 	<li>Talk to <span class="npc">Thorley Aethelred</span>.
@@ -2027,7 +2027,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 		<li>Dialogue: You need work to keep busy.</li>
 	</ol></li>
 	<li>Head directly SE across the street to Margarte’s House and wait until 9am.</li>
-	<li>Get the <span class="nirnroot">Nirnroot</span> in her house. It is through the first door on the right, then through the next door in that room.</li>
+	<li>Get the <span class="nirnroot" clid="0x0006F284">Nirnroot</span> in her house. It is through the first door on the right, then through the next door in that room.</li>
 	<li>Dupe 6 Ectoplasm and talk to <span class="npc">Margarte</span>.
 	<ol>
 		<li>Dialogue: Fighters Guild Jobs.</li>
@@ -2125,7 +2125,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 		<li>Dialogue: Galtus Previa.</li>
 		<li>Dialogue: No time. We’ve got to go.</li>
 	</ol></li>
-	<li>On the third floor, get the <span class="nirnroot">Nirnroot</span> and read <span class="book" clid="book38">The Legendary Sancre Tor [Blunt]</span> on a shelf.</li>
+	<li>On the third floor, get the <span class="nirnroot" clid="0x0006F261">Nirnroot</span> and read <span class="book" clid="book38">The Legendary Sancre Tor [Blunt]</span> on a shelf.</li>
 	<li>Fast travel to Quest Marker to enter Nonwyll Cavern. Make sure the quest updates once inside.</li>
 	<li>Follow the Quest Marker through the cave until you find a corpse in the second zone. The quest will update when this happens. Make sure <span class="npc">Viranus Donton</span> spawns next to you in the second zone.</li>
 	<li>Exit the cave, falling down to follow the path underneath the tunnel you went into to find the corpse. Take the first left in the first zone.</li>
@@ -2302,7 +2302,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 	<li>Once the Ogres are dead, fast travel back to Lord Rugdumph’s Estate (where the Quest Marker was in step 3).</li>
 	<li>Go into the main house and talk to <span class="npc">Lord Rugdumph gro-Shurak</span>.</li>
 	<li>Drop the quest reward, Rugdumph’s Sword.</li>
-	<li>Grab the <span class="nirnroot">Nirnroot</span> upstairs, in the NE corner of the second floor on a drawer.</li>
+	<li>Grab the <span class="nirnroot" clid="0x0006F289">Nirnroot</span> upstairs, in the NE corner of the second floor on a drawer.</li>
 	<li>Fast travel to Quest Marker to talk to <span class="npc">Burz gro-Khash</span>.
 	<ol>
 		<li>Dialogue: Lady Rogbut.</li>
@@ -2363,8 +2363,8 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 		<li>Dialogue: Join the Blackwood Company.</li>
 		<li>Advance predetermined dialogue.</li>
 	</ol></li>
-	<li>Get the <span class="nirnroot">Nirnroot</span> on the second floor walkway.</li>
-	<li>Enter Jeetum-Ze’s room and take the <span class="nirnroot">Nirnroot</span> on the dresser to your right.
+	<li>Get the <span class="nirnroot" clid="0x0006DC3F">Nirnroot</span> on the second floor walkway.</li>
+	<li>Enter Jeetum-Ze’s room and take the <span class="nirnroot" clid="0x0006F27F">Nirnroot</span> on the dresser to your right.
 	<ol>
 		<li>If this door does not open, load the PermaKey_Save and do the Perma Key glitch.</li>
 	</ol></li>
@@ -2645,7 +2645,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 			<li>Fast travel to Hackdirt, south of Chorrol.</li>
 			<li>Enter Moslin’s Inn directly behind you and invest in <span class="npc">Vlanhonder Moslin</span> using the B_Mercantile spell.</li>
 			<li>Head SSW to enter Mostlin’s Dry Goods and invest in <span class="npc">Etira Moslin</span> using the B_Mercantile spell.</li>
-			<li>Head NW to Natch Pinder’s House and take the Nirnroot upstairs.</li>
+			<li>Head NW to Natch Pinder’s House and take the <span class="nirnroot" clid="0x0006F266">Nirnroot</span> upstairs.</li>
 			<li>Head directly south into the broken building you face as you leave Natch Pinder’s House to enter a trapdoor on the ground next to a fireplace.</li>
 			<li>Progress through the cave system to find the cell with <span class="npc">Dar-Ma</span>. Talk to her.
 			<ol><li>Dialogue: I’ll let you out.</li></ol></li>
@@ -2674,7 +2674,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 			<li>Follow Quest Marker to talk to <span class="npc">Rallus Odiil</span>.
 			<ol><li>Dialogue: Valus Odiil</li></ol></li>
 			<li>Fast travel to Odiil farm, a village icon SE of Weynon Priory.</li>
-			<li>Get the Nirnroot inside the farmhouse.</li>
+			<li>Get the <span class="nirnroot" clid="0x0006F28E">Nirnroot</span> inside the farmhouse.</li>
 			<li>Harvest lettuce from the farm outside.</li>
 			<li>Wait 1 hour on the farm, and then look west and wait to see <span class="npc">Rallus Odiil</span> on the edge of the render distance. You may have to move a little closer to the farmhouse.</li>
 			<li>Once you see him, wait another hour to spawn him next to you at the farm.</li>
@@ -2884,7 +2884,7 @@ The Imperial Dragon Armor quest is used as the official end of the run, so it wi
 		<ol><li>Dialogue: Axe of Dragol.</li>
 		<li>Dialogue: Hunt.</li>
 		<li>Advance predetermined dialogue.</li></ol>
-		<li>Advance through the Hunter’s Run. You don’t need to kill the first hunter but optionally can to avoid enemy aggro. When you get to the first area with water, fall in and follow the tunnel out to collect the Nirnroot at the water’s edge. Make your way up through the tunnels and loop around back to the water area and jump up to the door above the bridge.</li>
+		<li>Advance through the Hunter’s Run. You don’t need to kill the first hunter but optionally can to avoid enemy aggro. When you get to the first area with water, fall in and follow the tunnel out to collect the <span class="nirnroot" clid="0x0006E4D2">Nirnroot</span> at the water’s edge. Make your way up through the tunnels and loop around back to the water area and jump up to the door above the bridge.</li>
 		<li>Find the Orc hunter in the next area and kill him. Wait for the quest to update, then take the key off his corpse.</li>
 		<li>Go back out the way you came. Quicksave before leaving the Hunter’s Run in case a glitch occurs.</li>
 		<li>Kill <span class="npc">Kurdan gro-Dragol</span> without talking to him.</li>
@@ -3324,11 +3324,11 @@ Make sure Acrobatics is no higher than 100 minus unread skill books minus 2. You
 	<li>Go back to the lobby and read <span class="book">The Wolf Queen, v 6 [Sneak]</span> on the bookshelf to your immediate right.</li>
 	<li>Fast travel to Quest Marker and walk onto the ship. The pirates will start attacking you automatically, so kill them at this point and make sure no random NPCs die. You will not get a bounty if they aggro you first.</li>
 	<li>Enter the ship and kill <span class="npc">Gaston Tussaud</span>.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> off the table.</li>
+	<li>Take the <span class="nirnroot" clid="0x0006D957">Nirnroot</span> off the table.</li>
 	<li>If you leave quickly enough, the pirates will spawn inside the ship as you are leaving it and not aggro you. Kill them if this doesn’t work.</li>
 	<li>Fast travel to Bruma East Gate and enter the second house on the right, Baenlin’s House.</li>
 	<li>Kill <span class="npc">Gromm</span> and <span class="npc">Baenlin</span>.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> upstairs in the NW corner of the floor on top of a drawer.</li>
+	<li>Take the <span class="nirnroot" clid="0x0006F24E">Nirnroot</span> upstairs in the NW corner of the floor on top of a drawer.</li>
 	<li>Fast travel to Chorrol North Gate and head south to Francois Motierre’s House.</li>
 	<li>Kill <span class="npc">Francois Motierre</span>.</li>
 	<li>Fast travel to Quest Marker to talk to <span class="npc">Vicente Valtieri</span>. The Quest Marker will always point to the well behind the house, but you will have to use the house until a later quest is completed. (This completes <span class="quest">A Watery Grave</span>)</li>
@@ -3674,7 +3674,7 @@ Make sure Acrobatics is no higher than 100 minus unread skill books minus 2. You
 		<li>Invest in <span class="npc">Enilroth</span> using the <span class="spellname">B_Mercantile</span> spell.</li>
 	</ol></li>
 	<li>Fast travel to Quest Marker and enter Ulfgar Fog-Eye’s House at the base of the lighthouse.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> on the windowsill above the bed in the side room.</li>
+	<li>Take the <span class="nirnroot" clid="0x0006F0C6">Nirnroot</span> on the windowsill above the bed in the side room.</li>
 	<li>Exit the lighthouse and enter the Cellar around the back of the lighthouse.
 	<ol>
 		<li>If this door does not open, load the PermaKey_Save and do the Perma Key glitch.</li>
@@ -3799,7 +3799,7 @@ How to do the Yield Glitch:
 	<li>Make sure you have this quest active instead of <span class="quest">Independent Thievery</span>.</li>
 	<li>Fast travel to Quest Marker. (Temple District)</li>
 	<li>Ignoring guards, make your way up the ladders.</li>
-	<li>Once you are on the top floor, get the <span class="nirnroot">Nirnroot</span> on the far end of the room.</li>
+	<li>Once you are on the top floor, get the <span class="nirnroot" clid="0x0006D973">Nirnroot</span> on the far end of the room.</li>
 	<li>Follow Quest Marker to open the Desk and take the Waterfront Tax Records out of it. Pay the gold fine if you get caught.</li>
 	<li>Exit the tower and fast travel to Quest Marker to talk to <span class="npc">Armand Christophe</span> around midnight.
 	<ol>
@@ -3839,7 +3839,7 @@ How to do the Yield Glitch:
 	<li>Read <span class="book">Thief [Acrobatics]</span> upstairs on the bottom shelf.</li>
 	<li>Fast travel to Leyawiin Castle and head NW through the archway and go into the yellow house on the right side of the street. (Ahdarji’s House)</li>
 	<li>Go upstairs and break into the west wing.</li>
-	<li>Go through the left door and take the <span class="nirnroot">Nirnroot</span> on the windowsill and read the skill book <span class="book">Ice and Chitin [Light Armor]</span> from the chest by the bed.</li>
+	<li>Go through the left door and take the <span class="nirnroot" clid="0x0006F27A">Nirnroot</span> on the windowsill and read the skill book <span class="book">Ice and Chitin [Light Armor]</span> from the chest by the bed.</li>
 	<li>Go back downstairs and talk to <span class="npc">Ahdarji</span>.
 	<ol>
 		<li>Dialogue: Ahdarji’s stolen ring.</li>
@@ -3952,7 +3952,7 @@ How to do the Yield Glitch:
 	<li>Fast travel to Castle Anvil, enter the main hall, and head all the way to the SW upstairs door to the private quarters.</li>
 	<li>Take a left and then the first right. Break into the room and open Dairihill’s Desk.</li>
 	<li>Take the List of Candidates from Dairihill’s Desk.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> in the back room behind the desk.</li>
+	<li>Take the <span class="nirnroot" clid="0x0006F0D1">Nirnroot</span> in the back room behind the desk.</li>
 	<li>Head NW down the hall and take the first left to enter the Royal Quarters.</li>
 	<li>Read <span class="book">King [Blunt]</span> on the SW bookshelf.</li>
 	<li>Exit the Royal Quarters the way you came in and continue NW down the hall to the farthest room and read <span class="book">The Red Kitchen Reader [Athletics]</span> on the desk.</li>
@@ -4053,7 +4053,7 @@ How to do the Yield Glitch:
 	<li>Kill a guard, then head back west down the hall and take a last right.</li>
 	<li>Activate the right Movable Pillar at the back wall opposite of the door twice to open it faster and go through the door.</li>
 	<li>Save clip running SSE into the door behind you</li>
-	<li>Head NE to get the <span class="nirnroot">Nirnroot</span>, then go SE through the door to the next zone.</li>
+	<li>Head NE to get the <span class="nirnroot" clid="0x0006F0FA">Nirnroot</span>, then go SE through the door to the next zone.</li>
 	<li>Hug the right wall without going through the big double door to reach the tower.</li>
 	<li>Outside in the tower, head up to the third floor and head to the SSE area to find the Key-Shaped Arrowhead in Fathis Aren’s Chest.</li>
 	<li>Exit out the SW door to the tower.
@@ -4107,7 +4107,7 @@ How to do the Yield Glitch:
 <div class="category" id="guide_ThievesGuild_TheUltimateHeist">
 <div class="categoryTitle">The Ultimate Heist</div>
 <ol>
-	<li>Fast travel to the Imperial City Arboretum and head NW into the water to get the <span class="nirnroot">Nirnroot</span>.</li>
+	<li>Fast travel to the Imperial City Arboretum and head NW into the water to get the <span class="nirnroot" clid="0x00070F95">Nirnroot</span>.</li>
 	<li>Head ENE to enter the South East Tunnel.</li>
 	<li>In the first zone, Save Clip through the SE corner to your immediate right by quicksaving while running into the corner, exiting the sewer, and quick loading while running. Head NNW to enter the door to the Beneath the Bloodworks zone.</li>
 	<li>Repeat the exact same Save Clip method into the SE corner to your immediate right. Head NNE to enter the Manhole Cover to the Palace Sewers. Activate this quest.</li>
@@ -4264,7 +4264,7 @@ How to do the Yield Glitch:
 	<li>Head to the SW corner of town and enter the Border Watch Inn.</li>
 	<li>Take the Olroy Cheese out of the blue display case to your right.</li>
 	<li>Invest in <span class="npc">S’thasa</span> using the <span class="spellname">B_Mercantile</span> spell.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> on the shelf behind the counter.</li>
+	<li>Take the <span class="nirnroot" clid="0x0006F22E">Nirnroot</span> on the shelf behind the counter.</li>
 	<li>Go back outside and head NNE to activate the cooking pot.
 	<ol>
 		<li>Select “Yes.”</li>
@@ -4383,7 +4383,7 @@ How to do the Yield Glitch:
 	</ol></li>
 	<li>Wait for the cutscene to end. Fast travel to Quest Marker.</li>
 	<li>Enter Torbal the Sufficient’s House, directly behind where you spawn.</li>
-	<li>Take the <span class="nirnroot">Nirnroot</span> on top of the cupboard to your right as you enter the house.
+	<li>Take the <span class="nirnroot" clid="0x0006F249">Nirnroot</span> on top of the cupboard to your right as you enter the house.
 	<ol>
 		<li>You should now have all 306 Nirnroots Found.</li>
 	</ol></li>


### PR DESCRIPTION
Added in clid's for city + indoor nirnroots to fix issue in v3 guide where multiple nirnroots in checklist and guide were being checked off at once. Additionally added nirnroot class to some instances of nirnroot in the guide where this was missing.