### PR TITLE
refactor progress load system, map updates

### DIFF
--- a/checklist.js
+++ b/checklist.js
@@ -167,15 +167,6 @@ function initMultiInternal(root, parentElement, depth, extraColumnName, leafCont
 // Functions that deal with progress
 //===========================
 
-function setParentChecked(checkbox){
-	if(checkbox.checked){
-		checkbox.parentElement.classList.add("checked");
-	}
-	else{
-		checkbox.parentElement.classList.remove("checked");
-	}
-}
-
 /**
  * called when user inputs data
  * @param {string} htmlRowId 

--- a/checklist.js
+++ b/checklist.js
@@ -3,7 +3,7 @@
 // Functions that generate the page
 //===========================
 function init(){
-	document.addEventListener("progressLoad",updateUIFromSaveData);
+	document.addEventListener("progressLoad",progress.updateProgressBar)
 	obliviondata.loadJsonData().then(()=>{
 		userdata.loadSettingsFromCookie();
 		//populate sections with json data.
@@ -187,50 +187,6 @@ function recalculateProgressAndUpdateProgressUI(){
 			element.parentElement.style = `background: linear-gradient(to right, green ${progress.toString()}%, crimson ${progress.toString()}%);`;
 		}
 	});
-}
-
-/**
- * helper function for updateUIFromSaveData
- * @param {} cell 
- */
-function updateHtmlElementFromSaveData(cell){
-	const classname = cell.hive.classname
-	let usableId = cell.formId;
-	if(usableId == null){
-		usableId = cell.id;
-	}
-	let checkbox = document.getElementById(classname+usableId+"check");
-	if(checkbox == null){
-		if(usableId != null && window.debug){
-			//user doesn't really need to know if this happens; it is expected for elements that don't draw.
-			console.warn("unable to find checkbox element for modifiable cell '"+classname+usableId+"' (id "+cell.id+")");
-		}
-		return;
-	}
-	let newval = null;
-	if(cell.ref == null){
-		//we call updateChecklistProgress so indirect elements will update from this
-		if(cell.id != null){
-			if(savedata[classname] == null){
-				debugger;
-			}
-			newval = savedata[classname][cell.id];
-			progress.updateChecklistProgress(null, newval, null, cell, true);
-		}
-	}
-}
-
-/**
- * When savedata is loaded, we need to bulk change all of the HTML to match the savedata state.
- * This function does that.
- */
-function updateUIFromSaveData(){
-	for(const klass of obliviondata.progressClasses){
-		const hive = obliviondata.jsondata[klass.name];
-		obliviondata.runOnTree(hive, updateHtmlElementFromSaveData);
-	}
-
-	recalculateProgressAndUpdateProgressUI();
 }
 
 function setParentChecked(checkbox){

--- a/checklist.js
+++ b/checklist.js
@@ -167,28 +167,6 @@ function initMultiInternal(root, parentElement, depth, extraColumnName, leafCont
 // Functions that deal with progress
 //===========================
 
-/**
- * Recalculate the total progress, and update UI elements.
- */
-function recalculateProgressAndUpdateProgressUI(){
-	let percentCompleteSoFar = localStorage.getItem("percentageDone");
-	
-	try{
-		percentCompleteSoFar = window.progress.recalculateProgress();
-	} catch{
-		
-	}
-	
-	//round progress to 2 decimal places
-	let progress = Math.round((percentCompleteSoFar * 100)*100)/100;
-	Array.of(...document.getElementsByClassName("totalProgressPercent")).forEach(element => {
-		element.innerText = progress.toString();
-		if(element.parentElement.className == "topbarSection" || element.parentElement.className == "popoutTopBarSection"){
-			element.parentElement.style = `background: linear-gradient(to right, green ${progress.toString()}%, crimson ${progress.toString()}%);`;
-		}
-	});
-}
-
 function setParentChecked(checkbox){
 	if(checkbox.checked){
 		checkbox.parentElement.classList.add("checked");
@@ -213,7 +191,7 @@ function userInputData(htmlRowId, checkboxElement){
 		}
 	}
 	
-	recalculateProgressAndUpdateProgressUI();
+	progress.updateProgressBar();
 }
 
 function checkboxClicked(event){

--- a/guide.js
+++ b/guide.js
@@ -14,9 +14,10 @@ function init(){
 	
 	window.addEventListener("resize",onWindowResize);
 	loadJsonData().then(()=>{
+		replaceElements();
 		loadProgressFromCookie();
 		sharing.initSharingFeature();
-		replaceElements();
+		progress.updateProgressBar();
 	});
 }
 
@@ -127,7 +128,6 @@ function replaceElements(){
 			}
 		}
 	}
-	updateUIFromSaveData();
 }
 
 
@@ -161,66 +161,6 @@ function getNpcData(npcElement){
 	return {name:npcName};
 }
 
-/**
- * Recalculate the total progress, and update UI elements.
- */
-function recalculateProgressAndUpdateProgressUI(){
-	let percentCompleteSoFar;
-	
-	try{
-		percentCompleteSoFar = window.progress.recalculateProgress();
-	} catch{
-		console.log("percentComplete got from localStorage");
-		percentCompleteSoFar = localStorage.getItem("percentageDone");
-	}
-	
-	// //round progress to 2 decimal places
-	// let progress = (percentCompleteSoFar * 100).toFixed(2);
-	// Array.of(...document.getElementsByClassName("totalProgressPercent")).forEach(element => {
-	// 	element.innerText = progress.toString();
-	// 	if(element.parentElement.className == "topbarSection"){
-	// 		element.parentElement.style = `background: linear-gradient(to right, green ${progress.toString()}%, red ${progress.toString()}%);`;
-	// 	}
-	// });
-}
-
-/**
- * helper function for updateUIFromSaveData. Does not call recalculateProgress().
- * @param {} cell 
- */
-function updateHtmlElementFromSaveData(cell){
-	const classname = cell.hive.classname
-	let usableId = cell.formId;
-	if(usableId == null){
-		usableId = cell.id;
-	}
-	let newval = null;
-	if(cell.ref == null){
-		//we call updateChecklistProgress so indirect elements will update from this
-		if(cell.id != null){
-			if(savedata[classname] == null){
-				debugger;
-			}
-			newval = savedata[classname][cell.id];
-			updateChecklistProgress(null, newval, null, cell, true);
-			//don't call recalculateProgress() because we do that in bulk in the calling function.
-		}
-	}
-}
-
-/**
- * When savedata is loaded, we need to bulk change all of the HTML to match the savedata state.
- * This function does that.
- */
-function updateUIFromSaveData(){
-	for(const klass of progressClasses){
-		const hive = jsondata[klass.name];
-		runOnTree(hive, updateHtmlElementFromSaveData);
-	}
-
-	recalculateProgressAndUpdateProgressUI();
-}
-
 function checkboxClicked(event){
 	const rowHtml = event.target.parentElement;
 
@@ -229,7 +169,7 @@ function checkboxClicked(event){
 	updateChecklistProgressFromInputElement(parentid, event.target, classname);
 	event.stopPropagation();
 	// we need to update because there might be multiple instances of the same book on this page, and we want to check them all.
-	recalculateProgressAndUpdateProgressUI();
+	progress.updateProgressBar();
 }
 
 function rowClicked(event){
@@ -261,8 +201,7 @@ function userInputData(rowHtml, checkboxElement){
 	var classname = rowHtml.classList[0];
 	let rowid = rowHtml.getAttribute("clid");
 	progress.updateChecklistProgressFromInputElement(rowid, checkboxElement, classname);
-	
-	recalculateProgressAndUpdateProgressUI();
+	progress.updateProgressBar();
 }
 
 //used to make sure we don't run a ton of refresh code constantly.

--- a/guide.js
+++ b/guide.js
@@ -13,11 +13,11 @@ function init(){
 	checkIframeSize(); 
 	
 	window.addEventListener("resize",onWindowResize);
+	document.addEventListener("progressLoad",progress.updateProgressBar)
 	loadJsonData().then(()=>{
 		replaceElements();
 		loadProgressFromCookie();
 		sharing.initSharingFeature();
-		progress.updateProgressBar();
 	});
 }
 
@@ -168,8 +168,6 @@ function checkboxClicked(event){
 	var classname = rowHtml.classList[0];
 	updateChecklistProgressFromInputElement(parentid, event.target, classname);
 	event.stopPropagation();
-	// we need to update because there might be multiple instances of the same book on this page, and we want to check them all.
-	progress.updateProgressBar();
 }
 
 function rowClicked(event){
@@ -201,7 +199,6 @@ function userInputData(rowHtml, checkboxElement){
 	var classname = rowHtml.classList[0];
 	let rowid = rowHtml.getAttribute("clid");
 	progress.updateChecklistProgressFromInputElement(rowid, checkboxElement, classname);
-	progress.updateProgressBar();
 }
 
 //used to make sure we don't run a ton of refresh code constantly.

--- a/js/map.mjs
+++ b/js/map.mjs
@@ -523,8 +523,8 @@ function initListeners(){
 
     document.getElementById("resetMapButton")?.addEventListener('click', (e)=>{
         if(confirm("Delete saved map progress?")){
-            resetProgressForHive(jsondata.location);
-            resetProgressForHive(jsondata.nirnroot);
+            resetProgressForHive(savedata, jsondata.location);
+            resetProgressForHive(savedata, jsondata.nirnroot);
             clearRandomGateCount();
             saveProgressToCookie();
             location.reload();

--- a/js/map.mjs
+++ b/js/map.mjs
@@ -27,7 +27,7 @@ export {
 
 import { Point } from "./map/point.mjs";
 import { MapPOI } from "./map/mapObject.mjs";
-import { sumCompletionItems } from "./progressCalculation.mjs";
+import { sumCompletionItems, updateProgressBar } from "./progressCalculation.mjs";
 import { saveProgressToCookie, initAutoSettings } from "./userdata.mjs"
 import { Overlay, OVERLAY_LAYER_NONE, OVERLAY_LAYER_LOCATIONS, OVERLAY_LAYER_NIRNROOTS, OVERLAY_LAYER_WAYSHRINES, OVERLAY_LAYER_NEARBYGATES } from "./map/overlay.mjs";
 import { findCell } from "./obliviondata.mjs";
@@ -531,7 +531,11 @@ function initListeners(){
         }
     });
 
-    document.addEventListener("progressLoad",()=>overlay.recalculateBoundingBox());
+    document.addEventListener("progressLoad",()=>{
+        updateProgressBar();
+        overlay.recalculateBoundingBox();
+        drawFrame();
+    });
 }
 
 function updateZoom(deltaZ, zoomPoint){

--- a/js/nirnroute.mjs
+++ b/js/nirnroute.mjs
@@ -12,6 +12,7 @@ import { saveCookie } from './userdata.mjs';
 var prevNirnroot;
 var thisNirnroot;
 var nextNirnroot;
+var thisNirnrootChecked;
 
 /**
  * Debugging function to get prev, this and next nirnroot.
@@ -56,6 +57,22 @@ function initEventListeners(){
         updateChecklistProgress(null, false, null, prevNirnroot.cell);
         recalculateProgress();
         activateNirnroot(prevNirnroot.cell.formId); 
+    });
+
+    
+	document.addEventListener("progressLoad",()=>{
+        // if after a progressLoad, the current nirn has
+        // been checked, advance to next unchecked nirn.
+        let newCheckedValue = savedata["nirnroot"][thisNirnroot.cell.id];
+        if(thisNirnrootChecked === false && newCheckedValue)
+        {
+            while(savedata["nirnroot"][thisNirnroot.cell.id] == true &&
+                nextNirnroot.cell.tspId != 0)
+            {
+                activateNirnroot(nextNirnroot.cell.formId);
+            }
+            newCheckedValue = savedata["nirnroot"][thisNirnroot.cell.id];
+        }
     });
 
     document.body.addEventListener('keyup', (evt)=>{
@@ -171,6 +188,7 @@ function activateNirnroot(nirnFormId){
     const nextToElement = document.getElementById("closeTo");
     nextToElement.innerText = getFastTravelInstructions(thisNirnroot);
 
+    thisNirnrootChecked = savedata["nirnroot"][thisNirnroot.cell.id];    
     
     map.zoomToFormId(nirnFormId);
     map.draw();

--- a/js/popout.mjs
+++ b/js/popout.mjs
@@ -66,25 +66,9 @@ function copyBrowserSourceToClipboard(){
 }
 
 function init(){
-    document.addEventListener("progressLoad",recalculateProgressAndUpdateProgressUI);
+    document.addEventListener("progressLoad",updateProgressBar);
 	obliviondata.loadJsonData().then(()=>{
         userdata.loadSettingsFromCookie();
         userdata.loadProgressFromCookie();
     });
-}
-
-/**
- * Recalculate the total progress, and update UI elements.
- */
-function recalculateProgressAndUpdateProgressUI(){
-	let percentCompleteSoFar = recalculateProgress();
-	
-	//round progress to 2 decimal places
-	let progress = Math.round((percentCompleteSoFar * 100)*100)/100;
-	Array.of(...document.getElementsByClassName("totalProgressPercent")).forEach(element => {
-		element.innerText = progress.toString();
-		if(element.parentElement.className == "topbarSection" || element.parentElement.className == "popoutTopBarSection"){
-			element.parentElement.style = `background: linear-gradient(to right, green ${progress.toString()}%, crimson ${progress.toString()}%);`;
-		}
-	});
 }

--- a/js/progressCalculation.mjs
+++ b/js/progressCalculation.mjs
@@ -6,17 +6,22 @@ export{
 	updateChecklistProgressFromInputElement,
 	updateChecklistProgress,
 	recalculateProgress,
-	sumCompletionItems,
 	clearProgressCache,
 	updateLocalProgress,
-	updateProgressBar
+	updateProgressBar,
+	sumCompletionItems
 }
 
 import { totalweight, getJsonData, findCell, runOnTree, progressClasses } from './obliviondata.mjs';
 import { uploadCurrentSave, uploadPartialSave } from './sharing.mjs';
 import { compressSaveData, decompressSaveData, upgradeSaveData, createNewSave, saveCookie, saveProgressToCookie } from './userdata.mjs';
 
-
+/**
+ * Helper function for updateLocalProgress. do not call directly.
+ * @param cell 
+ * @param targetSaveData 
+ * @param differential 
+ */
 function updateCellProgressFromTargetSaveData(cell, targetSaveData, differential)
 {
 	if(cell.ref != null || cell.id == null){
@@ -30,13 +35,14 @@ function updateCellProgressFromTargetSaveData(cell, targetSaveData, differential
 	if(!differential || newval != savedata[classname][cell.id]) {
 		updateChecklistProgress(null, newval, null, cell, true);
 	}
-	
 }
 
 /**
  * Update save data to new value and update progress accordingly.
  * Does not send data.
+ * One of the main function here you should call.
  * @param newSaveData new save data
+ * @param differential should we only update the cells that changed instead of updating everything
  */
 function updateLocalProgress(newSaveData, differential = false){
 	newSaveData = decompressSaveData(newSaveData);
@@ -62,6 +68,9 @@ function updateLocalProgress(newSaveData, differential = false){
 	document.dispatchEvent(new Event("progressLoad"));
 }
 
+/**
+ * Update progress bar on all the pages. Safe to call from anywhere.
+ */
 function updateProgressBar()
 {
 	//update progress percent
@@ -119,8 +128,7 @@ function updateChecklistProgressFromInputElement(formId, inputElement, classHint
  */
 function updateChecklistProgress(formId, newValue, classHint = null, cellHint = null, skipSave = false){
 	let cell = null;
-	if(cellHint != null)
-	{
+	if(cellHint != null) {
 		cell = cellHint;
 	}
 	else{

--- a/js/settings.mjs
+++ b/js/settings.mjs
@@ -72,23 +72,7 @@ function init(){
     document.body.addEventListener('dragover', ignoreEvent);
     document.body.addEventListener('drop', parseSave);
 
-    document.addEventListener("progressLoad",()=>{
-        let percentCompleteSoFar;
-        try{
-            percentCompleteSoFar = recalculateProgress();
-        } catch{
-            
-        }
-        
-        //round progress to 2 decimal places
-        let progress = Math.round((percentCompleteSoFar * 100)*100)/100;
-        Array.of(...document.getElementsByClassName("totalProgressPercent")).forEach(element => {
-            element.innerText = progress.toString();
-            if(element.parentElement.className == "topbarSection"){
-                element.parentElement.style = `background: linear-gradient(to right, green ${progress.toString()}%, crimson ${progress.toString()}%);`;
-            }
-        });
-    });
+    document.addEventListener("progressLoad",updateProgressBar());
 }
 
 function copyShareKeyToClipboard(){

--- a/js/settings.mjs
+++ b/js/settings.mjs
@@ -71,7 +71,7 @@ function init(){
     document.body.addEventListener('dragover', ignoreEvent);
     document.body.addEventListener('drop', parseSave);
 
-    document.addEventListener("progressLoad",updateProgressBar());
+    document.addEventListener("progressLoad",updateProgressBar);
 }
 
 function copyShareKeyToClipboard(){

--- a/js/settings.mjs
+++ b/js/settings.mjs
@@ -12,10 +12,9 @@ export{
 
 import { loadProgressFromCookie, saveProgressToCookie, initAutoSettings, loadSettingsFromCookie, saveCookie, loadCookie } from './userdata.mjs'
 import {loadJsonData} from './obliviondata.mjs'
-import { setRemoteUrl, createSpectateBanner } from './sharing.mjs'
-import {recalculateProgress} from './progressCalculation.mjs'
+import {updateProgressBar} from './progressCalculation.mjs'
 import { parseSave } from './saveReader.mjs'
-import { initSharingFeature, stopSpectating } from './sharing.mjs'
+import { initSharingFeature, stopSpectating, setRemoteUrl, createSpectateBanner } from './sharing.mjs'
 import { setPopoutShareCode } from './popout.mjs'
 
 //updateUIFromSaveData(); //this updates the %complete in topbar

--- a/js/sharing.mjs
+++ b/js/sharing.mjs
@@ -3,10 +3,7 @@
 
 import { base64ArrayBuffer } from "./base64ArrayBuffer.mjs";
 import { updateLocalProgress } from "./progressCalculation.mjs";
-import { resetProgress } from "./userdata.mjs";
-import { upgradeSaveData } from "./userdata.mjs";
-import { compressSaveData, decompressSaveData } from "./userdata.mjs";
-import { loadProgressFromCookie, saveCookie, loadCookie } from "./userdata.mjs";
+import { loadProgressFromCookie,	saveCookie,	loadCookie,	compressSaveData} from "./userdata.mjs";
 
 // ==============
 export {

--- a/js/sharing.mjs
+++ b/js/sharing.mjs
@@ -2,7 +2,7 @@
 // Contains code for sharing progress across the network.
 
 import { base64ArrayBuffer } from "./base64ArrayBuffer.mjs";
-import { updateAllProgress } from "./progressCalculation.mjs";
+import { updateLocalProgress } from "./progressCalculation.mjs";
 import { resetProgress } from "./userdata.mjs";
 import { upgradeSaveData } from "./userdata.mjs";
 import { compressSaveData, decompressSaveData } from "./userdata.mjs";
@@ -179,7 +179,8 @@ async function uploadCurrentSave(notifyOnUpdate = true){
 				settings.myShareCode = result.code;
 				saveCookie("settings",settings);
 			}
-			//todo: parse new savedata?
+			
+			updateLocalProgress(JSON.parse(result.response), true);
 
 			//do this every time we upload:
 			document.dispatchEvent(new Event("progressShared"));
@@ -335,7 +336,7 @@ async function startSpectating(notifyOnUpdate = true, updateGlobalSaveData = tru
 					alert("Downloaded");
 				}
 				
-				updateAllProgress(dl, true);
+				updateLocalProgress(dl, true);
 			}
 			else{
 				if(window.debug){
@@ -455,7 +456,7 @@ function startSync(updateGlobalSaveData)
 			settings.shareDownloadTime = dlTime.toDateString() + " " + dlTime.toTimeString().substring(0,8);
 			saveCookie("settings",settings);
 
-			updateAllProgress(dl, true);
+			updateLocalProgress(dl, true);
 		}
 		else{
 			if(window.debug){

--- a/js/userdata.mjs
+++ b/js/userdata.mjs
@@ -6,7 +6,9 @@ import { initShareSettings } from "./sharing.mjs";
 
 import {clearProgressCache} from './progressCalculation.mjs'
 import { downloadSave } from "./sharing.mjs";
-import { updateAllProgress } from "./progressCalculation.mjs";
+import { updateLocalProgress } from "./progressCalculation.mjs";
+import { initSharingFeature } from "./sharing.mjs";
+import { uploadCurrentSave } from "./sharing.mjs";
 
 //functions that save and load user progess and settings.
 export{
@@ -202,10 +204,6 @@ function saveProgressToCookie(){
  */
 function loadSettingsFromCookie(){
 	settings = loadCookie("settings");
-	if(settings.shareDownloadTimeInternal != null)
-	{
-		settings.shareDownloadTimeInternal = new Date(settings.shareDownloadTimeInternal);
-	}
 	initSettings();
 }
 
@@ -274,6 +272,11 @@ function initSettings(){
 	changed |= initProperty(settings, "classnameCheck", true);
 	changed |= initProperty(settings, "mapShowNonGates", true);
 	
+	if(settings.shareDownloadTimeInternal != null)
+	{
+		settings.shareDownloadTimeInternal = new Date(settings.shareDownloadTimeInternal);
+	}
+
 	//TODO: fix my shit encapsulation.
 	initShareSettings();
 
@@ -297,8 +300,8 @@ function loadProgressFromCookie(){
 	var compressed = loadCookie("progress");
 	
 	if(compressed && Object.getOwnPropertyNames(compressed).length != 0){
-		clearProgressCache();
-		updateAllProgress(compressed, true);
+		
+		updateLocalProgress(compressed);
 		return true;
 	}
 	else{
@@ -337,11 +340,10 @@ function resetProgressForHive(targetSaveData, hive)
 function createNewSave()
 {
 	if(jsondata == null){
-		loadJsonData('..').then(()=>{
+		return loadJsonData('..').then(()=>{
 			console.assert(jsondata != null);
-			createNewSave();
+			return createNewSave();
 		});
-		return;
 	}
 	
 	let targetSaveData = new Object();
@@ -364,7 +366,11 @@ function resetProgress(shouldConfirm=false){
 	}
 	if(execute){
 		let newdata = createNewSave();
-		updateAllProgress(newdata, true);
+		updateLocalProgress(newdata);
+		if(settings.myShareCode != null)
+		{
+			uploadCurrentSave();
+		}
 	}
 }
 

--- a/js/userdata.mjs
+++ b/js/userdata.mjs
@@ -1,14 +1,6 @@
-import { jsondata } from "./obliviondata.mjs";
-import { classes } from "./obliviondata.mjs";
-import { loadJsonData } from "./obliviondata.mjs";
-import { runOnTree, progressClasses } from "./obliviondata.mjs";
-import { initShareSettings } from "./sharing.mjs";
-
-import {clearProgressCache} from './progressCalculation.mjs'
-import { downloadSave } from "./sharing.mjs";
+import { jsondata, classes, loadJsonData, runOnTree, progressClasses } from "./obliviondata.mjs";
+import { initShareSettings, uploadCurrentSave } from "./sharing.mjs";
 import { updateLocalProgress } from "./progressCalculation.mjs";
-import { initSharingFeature } from "./sharing.mjs";
-import { uploadCurrentSave } from "./sharing.mjs";
 
 //functions that save and load user progess and settings.
 export{
@@ -157,16 +149,14 @@ function compressSaveData(saveDataObject){
 function decompressSaveData(compressedSaveData){
 	//expand cookie data back to nice, usable form.
 	var decompressedSaveData = {};
-	if(compressedSaveData.version < 11 || compressedSaveData.compressed == true)
-	{
+	if(compressedSaveData.version < 11 || compressedSaveData.compressed == true) {
 		for(const propname in compressedSaveData){
 			const matchingClass = classes.find(x=>x.name == propname);
 			if(matchingClass != null && matchingClass.standard) {
 				decompressedSaveData[propname] = {};
 				let elements = compressedSaveData[propname];
 				let length = elements.length;
-				if(elements.length == undefined)
-				{
+				if(elements.length == undefined){
 					length = Object.keys(elements).length;
 				}
 				for(let i = 0; i < length; i++){
@@ -231,8 +221,7 @@ function initSettings(){
 
 	//UPGRADES:
 	//use this (and bump the settings version) when there is a breaking change in the format.
-	if(settings.version < SETTINGS_VERSION || settings.version == null)
-	{
+	if(settings.version < SETTINGS_VERSION || settings.version == null)	{
 		switch(settings.version){
 			case null:
 			case undefined:
@@ -250,8 +239,7 @@ function initSettings(){
 				//deprecated
 			case 3:
 				// reset shareDownloadTimeInternal since we changed its type
-				if(settings.shareDownloadTimeInternal != undefined)
-				{
+				if(settings.shareDownloadTimeInternal != undefined) {
 					settings.shareDownloadTimeInternal = null;
 				}
 			default:

--- a/js/userdata.mjs
+++ b/js/userdata.mjs
@@ -6,6 +6,7 @@ import { initShareSettings } from "./sharing.mjs";
 
 import {clearProgressCache} from './progressCalculation.mjs'
 import { downloadSave } from "./sharing.mjs";
+import { updateAllProgress } from "./progressCalculation.mjs";
 
 //functions that save and load user progess and settings.
 export{
@@ -18,16 +19,17 @@ export{
 	loadSettingsFromCookie,
 	loadProgressFromCookie,
 	resetProgress,
+	createNewSave,
 	resetProgressForHive,
 	initAutoSettings
 }
 
 
-window.savedata = null;
+window.savedata = createNewSave();
 window.settings = null;
 
 const SAVEDATA_VERSION = 11;
-const SETTINGS_VERSION = 3;
+const SETTINGS_VERSION = 4;
 
 function saveCookie(name,valu){
 	var stringValue = JSON.stringify(valu);
@@ -69,24 +71,24 @@ window.migrate = function(){
 /**
  * Attempt to upgrade the save data stored in `savedata` to the most recent version.
  */
-function upgradeSaveData(shouldConfirm){
-	if(savedata.version == null){
+function upgradeSaveData(targetSaveData, shouldConfirm = true){
+	if(targetSaveData.version == null){
 		let reset = confirm("Save data is invalid or corrupted. Reset progress?");
 		if(reset){
-			resetProgress();
+			targetSaveData = createNewSave();
 		}
 	}
 	//we use ! >= so it'll handle stuff like undefined, nan, or strings.
-	if(!(savedata.version >= 5)){
+	if(!(targetSaveData.version >= 5)){
 		//tell user we can't upgrade.
 		let reset = confirm("Save data is out of date. Percentages may be wrong. Would you like to reset progress?");
 		if(reset){
-			resetProgress();
+			targetSaveData = createNewSave();
 		}
 	}
 	else{
 		var shouldAttemptUpgrade = false;
-		if(savedata.version < SAVEDATA_VERSION){
+		if(targetSaveData.version < SAVEDATA_VERSION){
 			if(shouldConfirm){
 				//ask if user wants to attempt upgrade
 				shouldAttemptUpgrade = confirm("Save data is out of date. Percentages may be wrong. Would you like to attempt upgrade?");
@@ -96,24 +98,24 @@ function upgradeSaveData(shouldConfirm){
 			}
 		}
 		if(shouldAttemptUpgrade){
-			switch(savedata.version){
+			switch(targetSaveData.version){
 				case 5:
 				case 6:
 					//from 6 to 7: 
 					//add fame class
-					savedata.fame = {};
+					targetSaveData.fame = {};
 				case 7:
-					resetProgressForHive(jsondata.fame);
+					resetProgressForHive(targetSaveData, jsondata.fame);
 				case 8:
 					//add nirnroot and locations in v9
-					savedata.nirnroot = {};
-					savedata.location = {};
-					resetProgressForHive(jsondata.nirnroot);
-					resetProgressForHive(jsondata.location);
+					targetSaveData.nirnroot = {};
+					targetSaveData.location = {};
+					resetProgressForHive(targetSaveData, jsondata.nirnroot);
+					resetProgressForHive(targetSaveData, jsondata.location);
 				case 9:
 				case 10:
 					//in 11, we just introduced the "compressed" variable.
-					savedata.version = SAVEDATA_VERSION;
+					targetSaveData.version = SAVEDATA_VERSION;
 					break;
 				default:
 					alert("error while upgrading");
@@ -121,8 +123,8 @@ function upgradeSaveData(shouldConfirm){
 			}
 			console.log("upgrade succeeded.");
 		}
-		saveProgressToCookie();
 	}
+	return targetSaveData;
 }
 
 //compress save data object for more efficient stringification
@@ -200,6 +202,10 @@ function saveProgressToCookie(){
  */
 function loadSettingsFromCookie(){
 	settings = loadCookie("settings");
+	if(settings.shareDownloadTimeInternal != null)
+	{
+		settings.shareDownloadTimeInternal = new Date(settings.shareDownloadTimeInternal);
+	}
 	initSettings();
 }
 
@@ -244,6 +250,12 @@ function initSettings(){
 			case 2:
 				//2 to 3: 
 				//deprecated
+			case 3:
+				// reset shareDownloadTimeInternal since we changed its type
+				if(settings.shareDownloadTimeInternal != undefined)
+				{
+					settings.shareDownloadTimeInternal = null;
+				}
 			default:
 				//done
 				break;
@@ -285,14 +297,8 @@ function loadProgressFromCookie(){
 	var compressed = loadCookie("progress");
 	
 	if(compressed && Object.getOwnPropertyNames(compressed).length != 0){
-		savedata = decompressSaveData(compressed);
-		if(savedata.version != SAVEDATA_VERSION){
-			upgradeSaveData();
-		}
-		//clear weight cache
 		clearProgressCache();
-		
-		document.dispatchEvent(new Event("progressLoad"));
+		updateAllProgress(compressed, true);
 		return true;
 	}
 	else{
@@ -307,11 +313,13 @@ function loadProgressFromCookie(){
 
 /**
  * Reset savedata progress for specific hive. Helper function for resetProgress.
+ * @param {object} targetSaveData save data to reset hive in
  * @param {object} hive hive to reset
  */
-function resetProgressForHive(hive){
+function resetProgressForHive(targetSaveData, hive)
+{
 	const classname = hive.classname;
-	savedata[classname] = {};
+	targetSaveData[classname] = {};
 	runOnTree(hive,(cell=>{
 		cell.cache = null;
 		if(cell.id == null){
@@ -319,11 +327,30 @@ function resetProgressForHive(hive){
 			return;
 		}
 		if(cell.type == "number"){
-			savedata[classname][cell.id] = 0;
+			targetSaveData[classname][cell.id] = 0;
 		}
 		else{
-			savedata[classname][cell.id] = false;
+			targetSaveData[classname][cell.id] = false;
 		}}));
+}
+
+function createNewSave()
+{
+	if(jsondata == null){
+		loadJsonData('..').then(()=>{
+			console.assert(jsondata != null);
+			createNewSave();
+		});
+		return;
+	}
+	
+	let targetSaveData = new Object();
+	targetSaveData.version = SAVEDATA_VERSION;
+	
+	for(const klass of progressClasses){
+		resetProgressForHive(targetSaveData, jsondata[klass.name]);
+	}
+	return targetSaveData;
 }
 
 /**
@@ -331,27 +358,14 @@ function resetProgressForHive(hive){
  * @param {boolean} shouldConfirm Should we confirm with the user or not
  */
 function resetProgress(shouldConfirm=false){
-	if(jsondata == null){
-		loadJsonData('..').then(()=>{
-			console.assert(jsondata != null);
-			resetProgress(shouldConfirm);
-		});
-		return;
-	}
 	var execute = true;
 	if(shouldConfirm){
 		execute = confirm("press OK to reset data");
 	}
 	if(execute){
-		savedata = new Object();
-		savedata.version = SAVEDATA_VERSION;
-		
-		for(const klass of progressClasses){
-			resetProgressForHive(jsondata[klass.name]);
-		}
+		let newdata = createNewSave();
+		updateAllProgress(newdata, true);
 	}
-	saveProgressToCookie();
-	document.dispatchEvent(new Event("progressLoad"));
 }
 
 /**

--- a/server/SaveDataEditor.cs
+++ b/server/SaveDataEditor.cs
@@ -73,7 +73,7 @@ namespace ShareApi
                         {
                             node.contents = newData;
                             var newNode = node.Commit();
-                            ProgressManager.Instance.UpdateSaveData(sql, shareCode, new ReadProgress(newNode, updateTime));
+                            ProgressManager.Instance.UpdateSaveData(sql, shareCode, new ReadProgress(newNode, DateTime.UtcNow));
                             return newNode;
                         }
                     }


### PR DESCRIPTION
refactor out updateProgressBar function
removed redundant code
resetProgressForHive now takes a savedata object instead of operating on the global one
add updateAllProgress function that takes in new savedata and calls update() on all the cells that have changed
minor optimization in progress cache clearing
change shareDownloadTimeInternal to a Date so it subtracts correctly and works as expected
added createNewSave() that creats a new save object outside of the global one
upgradeSaveData now takes a savedata object instead of operating on the global one
fixed issue where map wouldn't update after new save data was received
Nirnroute now auto advances if it detects that the current nirnroot has been checked off due to a save update.