### PR TITLE
Set up a better formatted Archive section

### DIFF
--- a/speedrun-4.html
+++ b/speedrun-4.html
@@ -64,6 +64,7 @@
 <article id="guide" class="mainPanel scrollablePanel" style="width: 55%;">
 
 <h1 style="text-align:center">Oblivion 100% Speedrun Route (V4)</h1>
+<p style="text-align:center; font-size: 14px;"><i>Release Date: February 23rd, 2023</i> (<a href="./speedrun-archive.html">View Patch Notes</a>)</p>
 <h3 style="text-align:center">Made by the PRCLive community.</h3>
 <button onclick="initSpeak()" id="enable_speech_btn">Enable speech</button><span> — <i>Use Text-to-Speech to narrate the guide. Spacebar advances to next line, and refresh page to disable.</i></span>
 

--- a/speedrun-archive.html
+++ b/speedrun-archive.html
@@ -58,13 +58,32 @@
 </div>
 <!-- end topbar-->
 <article class="mainPanel">
-    <h1>Oblivion 100% Speedrun Archive</h1>
-    <p>This is an archive of all the past versions of the speedrun route. To see a list of changes between versions, see this <a href="https://prclive.run/wiki/Oblivion:History_of_100%25">Wiki Article</a>.</p>
-    <p>Note that these versions are no longer considered optimal, and in some cases may have logic errors or be based on slightly different objectives that were later revised. <b>Use these at your own risk. Earlier route versions are way less consistent.</b></p>
-    <p><i>All the versions listed below existed prior to the creation of the interactive guide. These were hosted on Google Drive. They will eventually be updated to be made into non-interactive materials accessible directly on this site.</i></p>
-    <p><b><a href="https://drive.google.com/drive/folders/1RJ9aACDanO4vE5zS2Y5pR05ZaKeP3WKW?usp=share_link">Version 3</a></b> — The final version prior to interactive materials being implemented. An interactive version was made to develop website functionality, but is untested. Also included a Casual Guide for non-speedrunners.</p>
-    <p><b><a href="https://drive.google.com/drive/folders/1qKriYpDEERslA1uPB6-ue5XFrF16iKgX?usp=sharing">Version 2</a></b> — An overhaul of the route that focused on improved route materials in addition to logic. This version used a "Quest Manual" system where the player had to swap between the main guide and each quest instruction set as it appeared.</p>
-    <p><b><a href="https://docs.google.com/document/d/1aqQWD8quxXPmvHNxsVPie7fcQFB0LJUGIr_xGb5Ojdo/edit?usp=sharing">Version 1</a></b> — The first ever, with almost no functional route materials outside of the main guide. Utilized very few glitches and logic was very linear by category of objective.</p>
+    <h1 style="text-align: center;">Oblivion 100% Speedrun Archive</h1>
+    <p style="text-align: center;"><i>This is an archive of all the past versions of the speedrun route. To see a list of changes for pre-V4 releases, see this <a href="https://prclive.run/wiki/Oblivion:History_of_100%25">Wiki Article</a>.</i></p>
+    <div class="section">
+		<div class="sectionTitle">V4 Revisions</div>
+		<div class="collapsibleContent">
+			<p style="text-align: center;"><i>V4 is the current route logic system we use. All updates to the route logic for the foreseeable future will be building off of V4.0, with incremental changes noted below.</i></p>
+			<div class="collapsibleContent">
+				<p><b>Ver 4.1</b> (Work in Progress):</p>
+				<ul>
+					<li>Added getting the golbin shaman chest repair hammer to the Tutorial, and using that repair hammer to activate the Class Reset pop-up without having to do a frame perfect input.</li>
+					<li>Fixed various typos and small formatting errors.</li>
+				</ul>
+			</div>
+
+			<p><b><a href="./speedrun-4.html">Ver 4.0</a></b> (Feb 23rd, 2023) — The first version to use the website and a new logic system that focuses on reducing redundant visits to the same cell, rather than focusing on linearly completing quests. It was completed in February of 2023 but was not publicly available until March 14th, 2025.</p>
+		</div>
+	</div>
+	<div class="section">
+		<div class="sectionTitle">Old Versions</div>
+		<div class="collapsibleContent">
+			<p style="text-align: center;"><i><b>Use these at your own risk.</b> Previous versions are no longer optimal, didn't have website integration, and in some cases may have logic errors or be based on slightly different objectives that were later revised.</i></p>
+			<p><b><a href="https://drive.google.com/drive/folders/1RJ9aACDanO4vE5zS2Y5pR05ZaKeP3WKW?usp=share_link">Ver 3.0</a></b> (Aug 28th, 2021) — The final version prior to interactive materials being implemented. An interactive version was made to develop website functionality, but is untested. Also included a Casual Guide for non-speedrunners.</p>
+    		<p><b><a href="https://drive.google.com/drive/folders/1qKriYpDEERslA1uPB6-ue5XFrF16iKgX?usp=sharing">Ver 2.0</a></b> (Sep 25th, 2020) — An overhaul of the route that focused on improved route materials in addition to logic. This version used a "Quest Manual" system where the player had to swap between the main guide and each quest instruction set as it appeared.</p>
+    		<p><b><a href="https://docs.google.com/document/d/1aqQWD8quxXPmvHNxsVPie7fcQFB0LJUGIr_xGb5Ojdo/edit?usp=sharing">Ver 1.0</a></b> (July 21st, 2017) — The first ever, with almost no functional route materials outside of the main guide. Utilized very few glitches and logic was very linear by category of objective.</p>
+		</div>
+	</div>
 </article>
 <!-- BEGIN FOOTER-->
 <footer>
@@ -75,5 +94,5 @@
  </p>
 </footer>
 <!-- END FOOTER-->
-
+<script src="collapsible.js"></script>
 </body></html>


### PR DESCRIPTION
This may eventually get pushed to a wiki page instead for ease of editing the text, but for now we have a more readable system for showing the user new incremental changes to the route logic.

Also added a link to the patch notes (aka archive) at the top of the actual guide.

This is a small PR, but it sets it up so we can keep track of the future smaller V4.X route revisions and cleans up another page that had incomplete formatting.